### PR TITLE
Corrected "map-marker" glyph coordinates

### DIFF
--- a/Firmware/src/Firmware.ino
+++ b/Firmware/src/Firmware.ino
@@ -683,7 +683,7 @@ void Display_Task( void* param ){
         oled_ptr->drawStr(0,8,gps_lat_str);
         oled_ptr->drawStr(0,16,gps_lng_str);
         oled_ptr->setFont(u8g2_font_open_iconic_all_2x_t);
-        oled_ptr->drawGlyph(16,112,209);
+        oled_ptr->drawGlyph(112,16,209);
       } else {
          oled_ptr->setFont(u8g2_font_amstrad_cpc_extended_8f );
          oled_ptr->drawStr(24,16,"No GPS Fix");


### PR DESCRIPTION
The glyphs x and y coordinates were accidentially interchanged, so the glyph was never shown on the visible display area.